### PR TITLE
Fixes #38 - add additional parameter :first-time-only to norm map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.rkn/conformity "0.5.1"
+(defproject io.rkn/conformity "0.5.2"
   :description "Idempotent datom transacting for Datomic.\n\nSpecial thanks to Stuart Halloway for the original idea, implementation and permission to take it and run."
   :url "http://github.com/rkneufeld/conformity"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
This commit brings no breaking changes. One can avoid recalculation and reapplication of `txes`  by providing additional `:first-time-only true` kv pair to a norm.
PR, along with code, brings testing and README update.