### PR TITLE
Close reader in read-resource

### DIFF
--- a/src/io/rkn/conformity.clj
+++ b/src/io/rkn/conformity.clj
@@ -25,10 +25,10 @@
   ([resource-name]
    (read-resource {:readers *data-readers*} resource-name))
   ([opts resource-name]
-   (->> (io/resource resource-name)
-        (io/reader)
-        (java.io.PushbackReader.)
-        (clojure.edn/read opts))))
+   (with-open [reader (->> (io/resource resource-name)
+                           (io/reader)
+                           (java.io.PushbackReader.))]
+     (clojure.edn/read opts reader))))
 
 (defn index-attr
   "Returns the index-attr corresponding to a conformity-attr"


### PR DESCRIPTION
Previously the read-resource function would leave the reader open after it had read the given file. This may have caused issues for at least one user. Ref: #49. In any case it is probably good style to use `with-open` to ensure readers are closed.